### PR TITLE
[Feat/#57] 가데이터 생성 로직 구현 & loop/oauth2 제외한 나머지 도메인 스웨거 테스트 완료

### DIFF
--- a/src/main/java/com/loopone/loopinbe/domain/account/auth/controller/AuthController.java
+++ b/src/main/java/com/loopone/loopinbe/domain/account/auth/controller/AuthController.java
@@ -15,16 +15,16 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequestMapping("/rest-api/v1/auth")
 @RequiredArgsConstructor
-@Tag(name = "Auth", description = "인증/인가 API")
+@Tag(name = "Auth", description = "일반 인증 API")
 public class AuthController {
     private final AuthService authService;
 
-//    // 로그인
-//    @Operation(summary = "로그인", description = "계정ID와 비밀번호로 로그인합니다.")
-//    @PostMapping("/login")
-//    public ApiResponse<LoginResponse> login(@RequestBody @Valid LoginRequest loginRequest) {
-//        return ApiResponse.success(authService.login(loginRequest, false));
-//    }
+    // 로그인
+    @Operation(summary = "로그인", description = "계정ID와 비밀번호로 로그인합니다.(소셜 로그인은 비밀번호 검증 생략)")
+    @PostMapping("/login")
+    public ApiResponse<LoginResponse> login(@RequestBody @Valid LoginRequest loginRequest) {
+        return ApiResponse.success(authService.login(loginRequest, false));
+    }
 
     // 로그아웃
     @Operation(summary = "로그아웃", description = "현재 로그인된 사용자가 로그아웃합니다.")
@@ -37,7 +37,7 @@ public class AuthController {
     // accessToken 재발급
     @Operation(summary = "accessToken 재발급", description = "refresh 토큰을 사용하여 access 토큰을 재발급합니다.")
     @GetMapping("/refresh-token")
-    public ApiResponse<LoginResponse> refreshToken(@RequestHeader("Authorization") String refreshToken, @CurrentUser CurrentUserDto currentUser) {
+    public ApiResponse<LoginResponse> refreshToken(@RequestHeader("Authorization-Refresh") String refreshToken, @CurrentUser CurrentUserDto currentUser) {
         return ApiResponse.success(authService.refreshToken(refreshToken, currentUser));
     }
 }

--- a/src/main/java/com/loopone/loopinbe/domain/account/auth/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/loopone/loopinbe/domain/account/auth/security/JwtAuthenticationFilter.java
@@ -56,7 +56,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         boolean decodingSuccess = false;
         String email = "";
         try {
-            if (!jwtTokenProvider.validateToken(token)) {
+            if (!jwtTokenProvider.validateAccessToken(token)) {
                 log.warn("토큰이 유효하지 않습니다.");
                 responseUnauthorized(response, "유효하지 않은 Access Token 입니다.");
                 return;

--- a/src/main/java/com/loopone/loopinbe/domain/account/auth/serviceImpl/AuthServiceImpl.java
+++ b/src/main/java/com/loopone/loopinbe/domain/account/auth/serviceImpl/AuthServiceImpl.java
@@ -42,8 +42,8 @@ public class AuthServiceImpl implements AuthService {
         if (!isSocialLogin && !passwordEncoder.matches(loginRequest.getPassword(), member.getPassword())) {
             throw new RuntimeException("비밀번호가 올바르지 않습니다.");
         }
-        String accessToken = jwtTokenProvider.generateToken(member.getEmail(), accessTokenExpiration);
-        String refreshToken = jwtTokenProvider.generateToken(member.getEmail(), refreshTokenExpiration);
+        String accessToken = jwtTokenProvider.generateToken(member.getEmail(), "ACCESS",accessTokenExpiration);
+        String refreshToken = jwtTokenProvider.generateToken(member.getEmail(), "REFRESH",refreshTokenExpiration);
         // Refresh Token을 Redis에 저장
         refreshTokenService.saveRefreshToken(member.getId().toString(), refreshToken, refreshTokenExpiration);
         return new LoginResponse(accessToken, refreshToken);
@@ -68,11 +68,11 @@ public class AuthServiceImpl implements AuthService {
         if (storedRefreshToken == null || !storedRefreshToken.equals(refreshToken)) {
             throw new RuntimeException("유효하지 않은 리프레시 토큰입니다.");
         }
-        if (!jwtTokenProvider.validateToken(storedRefreshToken)) {
+        if (!jwtTokenProvider.validateRefreshToken(storedRefreshToken)) {
             throw new RuntimeException("리프레시 토큰이 만료되었습니다.");
         }
         String email = jwtTokenProvider.getEmailFromToken(storedRefreshToken);
-        String newAccessToken = jwtTokenProvider.generateToken(email, accessTokenExpiration);
+        String newAccessToken = jwtTokenProvider.generateToken(email, "ACCESS", accessTokenExpiration);
 
         return new LoginResponse(newAccessToken, storedRefreshToken);
     }

--- a/src/main/java/com/loopone/loopinbe/domain/account/member/controller/MemberController.java
+++ b/src/main/java/com/loopone/loopinbe/domain/account/member/controller/MemberController.java
@@ -14,8 +14,10 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.http.MediaType;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
@@ -66,8 +68,8 @@ public class MemberController {
 
     // 회원정보 수정
     @Operation(summary = "회원정보 수정", description = "현재 로그인된 사용자의 회원정보를 수정합니다.")
-    @PatchMapping
-    public ApiResponse<Void> updateMemberInfo(@RequestPart(value = "memberForm") @Valid MemberUpdateRequest memberUpdateRequest,
+    @PatchMapping(consumes = { MediaType.MULTIPART_FORM_DATA_VALUE })
+    public ApiResponse<Void> updateMemberInfo(@ParameterObject @ModelAttribute MemberUpdateRequest memberUpdateRequest,
                                               @RequestPart(value = "imageFile", required = false) MultipartFile imageFile,
                                               @CurrentUser CurrentUserDto currentUser) {
         memberService.updateMember(memberUpdateRequest, imageFile, currentUser);
@@ -85,9 +87,11 @@ public class MemberController {
     // 회원 검색하기
     @Operation(summary = "회원 검색", description = "현재 로그인된 사용자가 회원을 검색합니다.(기본설정: page=0, size=15)")
     @GetMapping("/search")
-    public ApiResponse<List<MemberResponse>> searchMemberInfo(@ModelAttribute MemberPage request, @RequestParam(value = "keyword") String keyword) {
+    public ApiResponse<List<MemberResponse>> searchMemberInfo(@ModelAttribute MemberPage request,
+                                                              @RequestParam(value = "keyword") String keyword,
+                                                              @CurrentUser CurrentUserDto currentUser) {
         Pageable pageable = PageRequest.of(request.getPage(), request.getSize());
-        return ApiResponse.success(memberService.searchMemberInfo(pageable, keyword));
+        return ApiResponse.success(memberService.searchMemberInfo(pageable, keyword, currentUser));
     }
 
     // 팔로우 요청하기

--- a/src/main/java/com/loopone/loopinbe/domain/account/member/converter/MemberConverter.java
+++ b/src/main/java/com/loopone/loopinbe/domain/account/member/converter/MemberConverter.java
@@ -31,29 +31,4 @@ public interface MemberConverter {
     // ---------- LoginUserDto <-> Member ----------
     Member toMember(CurrentUserDto source);
     CurrentUserDto toCurrentUserDto(Member source);
-
-    // ---------- List 단위 매핑(팔로우/요청) ----------
-    @Named("toFollowingMembers")
-    default List<SimpleMemberResponse> toFollowingMembers(List<MemberFollow> list, @Context SimpleMemberMapper mapper) {
-        return list == null ? List.of() :
-                list.stream().map(mapper::toFollowingMember).collect(Collectors.toList());
-    }
-
-    @Named("toFollowerMembers")
-    default List<SimpleMemberResponse> toFollowerMembers(List<MemberFollow> list, @Context SimpleMemberMapper mapper) {
-        return list == null ? List.of() :
-                list.stream().map(mapper::toFollowerMember).collect(Collectors.toList());
-    }
-
-    @Named("toSimpleMembersFromFollowReqs")
-    default List<SimpleMemberResponse> toSimpleMembersFromFollowReqs(List<MemberFollowReq> list, @Context SimpleMemberMapper mapper) {
-        return list == null ? List.of() :
-                list.stream().map(mapper::toSimpleMemberFromFollowReq).collect(Collectors.toList());
-    }
-
-    @Named("toSimpleMembersFromFollowRecs")
-    default List<SimpleMemberResponse> toSimpleMembersFromFollowRecs(List<MemberFollowReq> list, @Context SimpleMemberMapper mapper) {
-        return list == null ? List.of() :
-                list.stream().map(mapper::toSimpleMemberFromFollowRec).collect(Collectors.toList());
-    }
 }

--- a/src/main/java/com/loopone/loopinbe/domain/account/member/converter/SimpleMemberMapper.java
+++ b/src/main/java/com/loopone/loopinbe/domain/account/member/converter/SimpleMemberMapper.java
@@ -20,40 +20,54 @@ public interface SimpleMemberMapper {
     @Mapping(target = "profileImageUrl", source = "member.profileImageUrl")
     SimpleMemberResponse toSimpleMemberResponse(ChatRoomMember member);
 
+    // MemberFollow.follow -> SimpleMemberResponse (내가 '팔로잉'하는 사람)
     @Named("toFollowingMember")
-    SimpleMemberResponse toFollowingMember(MemberFollow mf); // mf.getFollowed() -> SimpleMemberResponse
+    @Mapping(target = "userId", source = "follow.id")
+    @Mapping(target = "userNickname", source = "follow.nickname")
+    @Mapping(target = "profileImageUrl", source = "follow.profileImageUrl")
+    SimpleMemberResponse toFollowerMember(MemberFollow mf);
 
+    // MemberFollow.followed -> SimpleMemberResponse (나를 '팔로우'하는 사람)
     @Named("toFollowerMember")
-    SimpleMemberResponse toFollowerMember(MemberFollow mf);  // mf.getFollow() -> SimpleMemberResponse
+    @Mapping(target = "userId", source = "followed.id")
+    @Mapping(target = "userNickname", source = "followed.nickname")
+    @Mapping(target = "profileImageUrl", source = "followed.profileImageUrl")
+    SimpleMemberResponse toFollowingMember(MemberFollow mf);
 
+    // MemberFollowReq.followReq -> SimpleMemberResponse (내가 팔로우 요청 보낸 대상)
     @Named("toSimpleMemberFromFollowReq")
+    @Mapping(target = "userId", source = "followRec.id")
+    @Mapping(target = "userNickname", source = "followRec.nickname")
+    @Mapping(target = "profileImageUrl", source = "followRec.profileImageUrl")
     SimpleMemberResponse toSimpleMemberFromFollowReq(MemberFollowReq req);
 
+    // MemberFollowReq.followRec -> SimpleMemberResponse (나한테 팔로우 요청한 사람)
     @Named("toSimpleMemberFromFollowRec")
+    @Mapping(target = "userId", source = "followReq.id")
+    @Mapping(target = "userNickname", source = "followReq.nickname")
+    @Mapping(target = "profileImageUrl", source = "followReq.profileImageUrl")
     SimpleMemberResponse toSimpleMemberFromFollowRec(MemberFollowReq req);
 
-    // ---------- MemberFollow.follow → SimpleMemberResponse ----------
+    // ---------- List 변환 ----------
+
     @Named("toFollowingMembers")
     default List<SimpleMemberResponse> toFollowingMembers(List<MemberFollow> list) {
         if (list == null) return List.of();
         return list.stream().map(this::toFollowingMember).toList();
     }
 
-    // ---------- MemberFollow.followed → SimpleMemberResponse ----------
     @Named("toFollowerMembers")
     default List<SimpleMemberResponse> toFollowerMembers(List<MemberFollow> list) {
         if (list == null) return List.of();
         return list.stream().map(this::toFollowerMember).toList();
     }
 
-    // ---------- MemberFollowReq.followReq → SimpleMemberResponse ----------
     @Named("toSimpleMembersFromFollowReqs")
     default List<SimpleMemberResponse> toSimpleMembersFromFollowReqs(List<MemberFollowReq> list) {
         if (list == null) return List.of();
         return list.stream().map(this::toSimpleMemberFromFollowReq).toList();
     }
 
-    // ---------- MemberFollowReq.followRec → SimpleMemberResponse ----------
     @Named("toSimpleMembersFromFollowRecs")
     default List<SimpleMemberResponse> toSimpleMembersFromFollowRecs(List<MemberFollowReq> list) {
         if (list == null) return List.of();

--- a/src/main/java/com/loopone/loopinbe/domain/account/member/dto/req/MemberCreateRequest.java
+++ b/src/main/java/com/loopone/loopinbe/domain/account/member/dto/req/MemberCreateRequest.java
@@ -18,7 +18,7 @@ import java.time.LocalDate;
 public class MemberCreateRequest {
     @NotBlank String email;
 //    @NotBlank(groups = RegularSignUp.class)
-//    String password;    // 일반 회원가입 때만 필수
+    String password;    // 일반 회원가입 때만 필수
     String nickname;
 //    String phone;
 //    Member.Gender gender;

--- a/src/main/java/com/loopone/loopinbe/domain/account/member/repository/MemberRepository.java
+++ b/src/main/java/com/loopone/loopinbe/domain/account/member/repository/MemberRepository.java
@@ -36,6 +36,7 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
             "LEFT JOIN MemberFollow f1 ON f1.follow.id = m.id " +
             "LEFT JOIN MemberFollow f2 ON f2.followed.id = m.id " +
             "WHERE m.nickname LIKE %:keyword% " +
-            "GROUP BY m.id, m.nickname, m.profileImageUrl")
-    Page<MemberResponse> findByKeyword(Pageable pageable, @Param("keyword") String keyword);
+            "AND m.id <> :currentUserId " +   // 본인 제외
+            "GROUP BY m.id, m.nickname, m.profileImageUrl, m.chatRoomId")
+    Page<MemberResponse> findByKeyword(Pageable pageable, @Param("keyword") String keyword, @Param("currentUserId") Long currentUserId);
 }

--- a/src/main/java/com/loopone/loopinbe/domain/account/member/service/MemberService.java
+++ b/src/main/java/com/loopone/loopinbe/domain/account/member/service/MemberService.java
@@ -36,7 +36,7 @@ public interface MemberService {
     void deleteMember(CurrentUserDto currentUser);
 
     // 회원 검색하기
-    PageResponse<MemberResponse> searchMemberInfo(Pageable pageable, String keyword);
+    PageResponse<MemberResponse> searchMemberInfo(Pageable pageable, String keyword,  CurrentUserDto currentUser);
 
     // 팔로우 요청하기
     void followReq(Long memberId, CurrentUserDto currentUser);

--- a/src/main/java/com/loopone/loopinbe/domain/account/oauth2/controller/OAuth2Controller.java
+++ b/src/main/java/com/loopone/loopinbe/domain/account/oauth2/controller/OAuth2Controller.java
@@ -24,7 +24,7 @@ import java.net.URI;
 @RestController
 @RequestMapping("/rest-api/v1/oauth2")
 @RequiredArgsConstructor
-@Tag(name = "OAuth2", description = "소셜인증 API")
+@Tag(name = "OAuth2", description = "소셜 인증 API")
 public class OAuth2Controller {
     private final AuthService authService;
     private final OAuth2Service oAuth2Service;

--- a/src/main/java/com/loopone/loopinbe/domain/notification/controller/NotificationController.java
+++ b/src/main/java/com/loopone/loopinbe/domain/notification/controller/NotificationController.java
@@ -20,7 +20,7 @@ import java.util.List;
 @RestController
 @RequestMapping("/rest-api/v1/notification")
 @RequiredArgsConstructor
-@Tag(name = "FCM", description = "FCM API")
+@Tag(name = "Notification", description = "알림 API")
 public class NotificationController {
     private final NotificationService notificationService;
 

--- a/src/main/java/com/loopone/loopinbe/domain/notification/serviceImpl/NotificationServiceImpl.java
+++ b/src/main/java/com/loopone/loopinbe/domain/notification/serviceImpl/NotificationServiceImpl.java
@@ -10,6 +10,7 @@ import com.loopone.loopinbe.domain.notification.converter.NotificationConverter;
 import com.loopone.loopinbe.domain.notification.dto.req.NotificationRequest;
 import com.loopone.loopinbe.domain.notification.dto.res.NotificationResponse;
 import com.loopone.loopinbe.domain.notification.entity.Notification;
+import com.loopone.loopinbe.domain.notification.entity.NotificationPage;
 import com.loopone.loopinbe.domain.notification.repository.NotificationRepository;
 import com.loopone.loopinbe.domain.notification.service.NotificationService;
 import com.loopone.loopinbe.global.common.response.PageResponse;
@@ -108,7 +109,7 @@ public class NotificationServiceImpl implements NotificationService {
 
     // 요청 페이지 수 제한
     private void checkPageSize(int pageSize) {
-        int maxPageSize = MemberPage.getMaxPageSize();
+        int maxPageSize = NotificationPage.getMaxPageSize();
         if (pageSize > maxPageSize) {
             throw new ServiceException(ReturnCode.PAGE_REQUEST_FAIL);
         }

--- a/src/main/java/com/loopone/loopinbe/global/config/SwaggerConfig.java
+++ b/src/main/java/com/loopone/loopinbe/global/config/SwaggerConfig.java
@@ -1,0 +1,20 @@
+package com.loopone.loopinbe.global.config;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.security.SecurityScheme;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@SecurityScheme(
+        name = "bearerAuth",
+        type = SecuritySchemeType.HTTP,
+        scheme = "bearer",
+        bearerFormat = "JWT"
+)
+@OpenAPIDefinition(
+        security = @SecurityRequirement(name = "bearerAuth")
+)
+public class SwaggerConfig {
+}

--- a/src/main/java/com/loopone/loopinbe/global/exception/ReturnCode.java
+++ b/src/main/java/com/loopone/loopinbe/global/exception/ReturnCode.java
@@ -114,6 +114,7 @@ public enum ReturnCode {
     ALREADY_FOLLOW(409, "FOLLOW_003", "이미 팔로우 중인 사용자입니다."),
     FOLLOWER_NOT_FOUND(404, "FOLLOW_004", "팔로워를 찾을 수 없습니다."),
     FOLLOW_NOT_FOUND(404, "FOLLOW_005", "팔로우한 사용자를 찾을 수 없습니다."),
+    CANNOT_FOLLOW_SELF(404, "FOLLOW_006", "자기 자신을 팔로우 할 수 없습니다."),
 
     // Notification
     NOTIFICATION_NOT_FOUND(404, "NOTIFICATION_001", "해당 알림을 찾을 수 없습니다."),

--- a/src/main/java/com/loopone/loopinbe/global/initData/NotProd.java
+++ b/src/main/java/com/loopone/loopinbe/global/initData/NotProd.java
@@ -7,7 +7,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
 
 @Configuration
-@Profile("prod")
+@Profile("!prod")
 public class NotProd {
     @Bean
     public ApplicationRunner applicationRunner(NotProdService notProdService) {

--- a/src/main/java/com/loopone/loopinbe/global/initData/service/NotProdMemberService.java
+++ b/src/main/java/com/loopone/loopinbe/global/initData/service/NotProdMemberService.java
@@ -1,6 +1,11 @@
 package com.loopone.loopinbe.global.initData.service;
 
-import com.loopone.loopinbe.domain.account.member.converter.MemberConverter;
+import com.loopone.loopinbe.domain.account.member.dto.req.MemberCreateRequest;
+import com.loopone.loopinbe.domain.account.member.entity.Member;
+import com.loopone.loopinbe.domain.account.member.repository.MemberRepository;
+import com.loopone.loopinbe.domain.account.member.service.MemberService;
+import com.loopone.loopinbe.global.exception.ReturnCode;
+import com.loopone.loopinbe.global.exception.ServiceException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -12,203 +17,20 @@ import java.util.*;
 @Service
 @RequiredArgsConstructor
 public class NotProdMemberService {
-//    private final AdminService adminService;
-//    private final MemberService memberService;
-//    private final MemberRepository memberRepository;
-//    private final NotProdUtils notProdUtils;
-//    private final MemberConverter memberConverter;
-//    private final Random random = new Random();
+    private final MemberService memberService;
 
-//    // 학생 가데이터 생성
-//    public void createStudents(List<Long> studentIds, List<String> studentPasswords, List<Long> allStudentIds, List<String> allStudentPasswords) {
-//        int emailCounter = 1;
-//        Map<Integer, Set<Long>> gradeUsedSuffixMap = new HashMap<>();
-//        for (int grade = 1; grade <= 3; grade++) {
-//            int birthYear = 2010 - grade;
-//            String gradePrefix = String.valueOf(2026 - grade);
-//            gradeUsedSuffixMap.put(grade, new HashSet<>());
-//
-//            for (int classId = 1; classId <= 7; classId++) {
-//                Set<String> usedNames = new HashSet<>();
-//
-//                for (int number = 1; number <= 25; number++) {
-//                    String name = notProdUtils.generateRandomFullName(false);
-//                    usedNames.add(name);
-//
-//                    LocalDate birthday = notProdUtils.generateRandomBirthday(birthYear, birthYear);
-//                    String password = notProdUtils.generatePasswordFromBirthday(birthday);
-//
-//                    long studentSuffix;
-//                    do {
-//                        studentSuffix = 10000 + random.nextInt(90000); // 5자리
-//                    } while (gradeUsedSuffixMap.get(grade).contains(studentSuffix));
-//                    gradeUsedSuffixMap.get(grade).add(studentSuffix);
-//                    long accountId = Long.parseLong(gradePrefix + studentSuffix);
-//                    allStudentIds.add(accountId);       // 모든 학생 ID 추가
-//                    allStudentPasswords.add(password);  // 모든 학생 Password 추가
-//                    String email = "student" + (emailCounter++) + "@school.com";
-//                    String phone = notProdUtils.generateRandomPhone();
-//
-//                    // 1~3학년 1반 1번 학생의 정보 저장
-//                    if (grade <= 3 && classId == 1 && number == 1) {
-//                        studentIds.add(accountId);
-//                        studentPasswords.add(password);
-//                    }
-//                    MemberRequest student = MemberRequest.builder()
-//                            .accountId(accountId)
-//                            .password(password)
-//                            .name(name)
-//                            .phone(phone)
-//                            .email(email)
-//                            .birthday(birthday)
-//                            .schoolName("송도고등학교")
-//                            .year(grade)
-//                            .classId(classId)
-//                            .number(number)
-//                            .gender(random.nextBoolean() ? Member.Gender.MALE : Member.Gender.FEMALE)
-//                            .role(Member.MemberRole.ROLE_STUDENT)
-//                            .state(Member.State.NORMAL)
-//                            .build();
-//                    adminService.sudoSignup(student);
-//                }
-//            }
-//        }
-//        System.out.println("-- 총 525명의 학생 가데이터 생성 완료! --");
-//    }
-//
-//    // 학부모 가데이터 생성
-//    public void createParents(List<Long> studentIds, List<Long> parentIds, List<Long> allStudentIds, List<String> allStudentPasswords, List<Long> allParentIds) {
-//        for (int i = 0; i < allStudentIds.size(); i++) {
-//            Long studentAccountId = allStudentIds.get(i);
-//            String studentPassword = allStudentPasswords.get(i);
-//            String name = notProdUtils.generateRandomFullName(true);
-//            int randomTwoDigits = random.nextInt(90) + 10;
-//            Long parentAccountId = Long.parseLong(studentAccountId + String.valueOf(randomTwoDigits));
-//
-//            ParentSignUpRequest parentSignUpRequest = ParentSignUpRequest.builder()
-//                    .accountId(parentAccountId)
-//                    .password(studentPassword)
-//                    .name(name)
-//                    .phone(notProdUtils.generateRandomPhone())
-//                    .email("parent_" + (i+1) + "@school.com")
-//                    .birthday(notProdUtils.generateRandomBirthday(1970, 1995))
-//                    .schoolName("송도고등학교")
-//                    .gender(random.nextBoolean() ? Member.Gender.MALE : Member.Gender.FEMALE)
-//                    .build();
-//            memberService.signup(parentSignUpRequest);
-//            allParentIds.add(parentAccountId);
-//
-//            // 1학년 1반 1번~3학년 1반 1번 학생 학부모만 별도 저장
-//            if (studentAccountId.equals(studentIds.get(0)) ||
-//                    studentAccountId.equals(studentIds.get(1)) ||
-//                    studentAccountId.equals(studentIds.get(2))) {
-//                parentIds.add(parentAccountId);
-//            }
-//        }
-//        System.out.println("-- 총 525명의 학부모 계정 생성 완료! --");
-//    }
-//
-//    // 학생/학부모 팔로우
-//    public void followChild(List<Long> allStudentIds, List<Long> allParentIds) {
-//        for (int i = 0; i < allStudentIds.size(); i++) {
-//            Long studentId = allStudentIds.get(i);
-//            Long parentId = allParentIds.get(i);
-//            Optional<Member> optionalStudent = memberRepository.findByAccountId(studentId);
-//            Optional<Member> optionalParent = memberRepository.findByAccountId(parentId);
-//            if (optionalStudent.isEmpty() || optionalParent.isEmpty()) {
-//                log.warn("학생 또는 학부모 정보가 없습니다. studentId: {}, parentId: {}", studentId, parentId);
-//                continue;
-//            }
-//
-//            Member student = optionalStudent.get();
-//            Member parent = optionalParent.get();
-//            CurrentUserDto parentLogin = memberMapper.toLoginUserDto(parent);
-//            CurrentUserDto studentLogin = memberMapper.toLoginUserDto(student);
-//
-//            FollowRequest followRequest = new FollowRequest();
-//            followRequest.setName(student.getName());
-//            followRequest.setYear(student.getYear());
-//            followRequest.setClassId(student.getClassId());
-//            followRequest.setNumber(student.getNumber());
-//            followRequest.setBirthday(student.getBirthday());
-//            try {
-//                memberService.followReq(followRequest, parentLogin);
-//                memberService.acceptFollowReq(parent.getId(), studentLogin);
-//            } catch (Exception e) {
-//                log.error("팔로우 처리 중 예외 발생 - studentId: {}, parentId: {}", studentId, parentId, e);
-//            }
-//        }
-//        log.info("-- 총 {} 쌍의 학부모-자녀 팔로우 생성 완료! --", allStudentIds.size());
-//    }
-//
-//    // 선생님 가데이터 생성
-//    public void createTeachers(List<Long> teacherIds, List<String> teacherPasswords) {
-//        List<Member.Subject> subjectList = List.of(Member.Subject.values());
-//        int teacherEmailCount = 1;
-//
-//        for (int year = 1; year <= 3; year++) {
-//            List<Integer> classIds = notProdUtils.getRandomUniqueNumbers(1, 7, 7);
-//            List<Member.Subject> shuffleSubjectList = new ArrayList<>(subjectList);
-//            Collections.shuffle(shuffleSubjectList);
-//
-//            for (int i = 0; i < 17; i++) {
-//                String name = notProdUtils.generateRandomFullName(true);
-//                LocalDate birthday = notProdUtils.generateRandomBirthday(1970, 1995);
-//                String password = notProdUtils.generatePasswordFromBirthday(birthday);
-//                Long accountId = notProdUtils.generateAccountId();
-//                String phone = notProdUtils.generateRandomPhone();
-//                String email = "teacher" + (teacherEmailCount++) + "@school.com";
-//
-//                MemberRequest teacher = MemberRequest.builder()
-//                        .accountId(accountId)
-//                        .password(password)
-//                        .name(name)
-//                        .phone(phone)
-//                        .email(email)
-//                        .birthday(birthday)
-//                        .schoolName("송도고등학교")
-//                        .year(year)
-//                        .subject(subjectList.get(i))
-//                        .gender(random.nextBoolean() ? Member.Gender.MALE : Member.Gender.FEMALE)
-//                        .role(Member.MemberRole.ROLE_TEACHER)
-//                        .state(Member.State.NORMAL)
-//                        .build();
-//                if (i < 7) {
-//                    teacher.setClassId(classIds.get(i));
-//                }
-//
-//                // 1~3학년 1반 선생님의 정보 저장
-//                if (year <= 3 && i < 7 && classIds.get(i) == 1) {
-//                    teacherIds.add(accountId);
-//                    teacherPasswords.add(password);
-//                }
-//                adminService.sudoSignup(teacher);
-//            }
-//        }
-//        System.out.println("-- 테스트용 교사 51명 생성 완료! --");
-//    }
-//
-//    // 관리자 가데이터 생성
-//    public void createAdmin(List<Long> adminAccountIdHolder, List<String> adminPasswordHolder) {
-//        Long accountId = notProdUtils.generateRandom9DigitAccountId();
-//        String password = "iEdu77";
-//        String phone = notProdUtils.generateRandomPhone();
-//
-//        MemberRequest adminForm = MemberRequest.builder()
-//                .accountId(accountId)
-//                .password(password)
-//                .name("김송도")
-//                .phone(phone)
-//                .email("admin1@school.com")
-//                .birthday(notProdUtils.generateRandomBirthday(1970, 1995))
-//                .schoolName("송도고등학교")
-//                .gender(random.nextBoolean() ? Member.Gender.MALE : Member.Gender.FEMALE)
-//                .role(Member.MemberRole.ROLE_ADMIN)
-//                .state(Member.State.NORMAL)
-//                .build();
-//        adminService.sudoSignup(adminForm);
-//        adminAccountIdHolder.add(accountId);
-//        adminPasswordHolder.add(password);
-//        System.out.println("-- 관리자 1명 생성 완료! --");
-//    }
+    // 유저 1 ~ 5 생성
+    public void createMembers(List<String> memberEmails, List<String> memberPasswords) {
+        List<String> nicknames = List.of("seoul_gangnam", "incheon_songdo", "gangneung_beach", "busan_haeundae", "jeju_seaside");
+        for (int i = 0; i < nicknames.size(); i++){
+            MemberCreateRequest memberCreateRequest = MemberCreateRequest.builder()
+                    .nickname(nicknames.get(i))
+                    .email("user" + (i + 1) + "@example.com")
+                    .password("1234")
+                    .build();
+            Member member = memberService.regularSignUp(memberCreateRequest);
+            memberEmails.add(member.getEmail());
+            memberPasswords.add("1234");
+        }
+    }
 }

--- a/src/main/java/com/loopone/loopinbe/global/initData/service/NotProdPrintTestAccount.java
+++ b/src/main/java/com/loopone/loopinbe/global/initData/service/NotProdPrintTestAccount.java
@@ -6,33 +6,16 @@ public class NotProdPrintTestAccount {
 
     // 가데이터 정보 출력
     public static void printTestAccounts(
-            List<Long> studentIds,
-            List<String> studentPasswords,
-            List<Long> parentIds,
-            List<Long> teacherIds,
-            List<String> teacherPasswords,
-            String adminAccountId,
-            String adminPassword,
+            List<String> memberEmails,
+            List<String> memberPasswords,
             long executionTimeMillis
     ) {
-        System.out.println("\n\n--- 학생/학부모 계정 정보 (1~3학년 1반 1번 학생/학부모) ---");
-        for (int i = 0; i < studentIds.size(); i++) {
-            System.out.println("\n--- " + (i + 1) + "학년 1반 1번 학생 ---");
-            System.out.println("계정 ID: " + studentIds.get(i));
-            System.out.println("학부모 계정 ID: " + parentIds.get(i));
-            System.out.println("비밀번호: " + studentPasswords.get(i));
+        System.out.println("\n\n--- 회원 더미데이터 계정 정보 ---");
+        for (int i = 0; i < memberEmails.size(); i++) {
+            System.out.println("\n--- 회원 " + (i + 1) + " ---");
+            System.out.println("이메일: " + memberEmails.get(i));
+            System.out.println("비밀번호: " + memberPasswords.get(i));
         }
-
-        System.out.println("\n\n--- 선생님 계정 정보 (1~3학년 1반 선생님) ---");
-        for (int i = 0; i < teacherIds.size(); i++) {
-            System.out.println("\n--- " + (i + 1) + "학년 1반 선생님 ---");
-            System.out.println("계정 ID: " + teacherIds.get(i));
-            System.out.println("비밀번호: " + teacherPasswords.get(i));
-        }
-
-        System.out.println("\n\n--- 관리자 계정 정보 ---");
-        System.out.println("계정 ID: " + adminAccountId);
-        System.out.println("비밀번호: " + adminPassword);
 
         // 실행 시간 출력 (시/분/초 단위로)
         long seconds = executionTimeMillis / 1000 % 60;

--- a/src/main/java/com/loopone/loopinbe/global/initData/service/NotProdService.java
+++ b/src/main/java/com/loopone/loopinbe/global/initData/service/NotProdService.java
@@ -13,46 +13,25 @@ import java.util.List;
 @RequiredArgsConstructor
 public class NotProdService {
     private final NotProdMemberService notProdMemberService;
-    private final List<Long> studentIds = new ArrayList<>();
-    private final List<Long> allStudentIds = new ArrayList<>();
-    private final List<String> studentPasswords = new ArrayList<>();
-    private final List<String> allStudentPasswords = new ArrayList<>();
-    private final List<Long> parentIds = new ArrayList<>();
-    private final List<Long> allParentIds = new ArrayList<>();
-    private final List<Long> teacherIds = new ArrayList<>();
-    private final List<String> teacherPasswords = new ArrayList<>();
-    List<Long> adminIdHolder = new ArrayList<>();
-    List<String> adminPwHolder = new ArrayList<>();
-    private Long adminAccountId;
-    private String adminPassword;
+    private List<String> memberEmails = new ArrayList<>();
+    private List<String> memberPasswords = new ArrayList<>();
 
     // 1) 트랜잭션 내 데이터 생성 메서드
     @Transactional
     public void initDummyDataTransactional() {
-//        notProdMemberService.createStudents(studentIds, studentPasswords, allStudentIds, allStudentPasswords);
-//        notProdMemberService.createParents(studentIds, parentIds, allStudentIds, allStudentPasswords, allParentIds);
-//        notProdMemberService.followChild(allStudentIds, allParentIds);
-//        notProdMemberService.createTeachers(teacherIds, teacherPasswords);
-//        notProdMemberService.createAdmin(adminIdHolder, adminPwHolder);
-//        this.adminAccountId = adminIdHolder.get(0);
-//        this.adminPassword = adminPwHolder.get(0);
+        notProdMemberService.createMembers(memberEmails, memberPasswords);
     }
 
     // 2) 트랜잭션 커밋 후 가데이터 정보 출력
     public void initDummyData() {
-//        long start = System.currentTimeMillis();
-//        initDummyDataTransactional();
-//        long end = System.currentTimeMillis();
-//        long executionTimeMillis = end - start;
-//        NotProdPrintTestAccount.printTestAccounts(
-//                studentIds,
-//                studentPasswords,
-//                parentIds,
-//                teacherIds,
-//                teacherPasswords,
-//                String.valueOf(adminAccountId),
-//                adminPassword,
-//                executionTimeMillis
-//        );
+        long start = System.currentTimeMillis();
+        initDummyDataTransactional();
+        long end = System.currentTimeMillis();
+        long executionTimeMillis = end - start;
+        NotProdPrintTestAccount.printTestAccounts(
+                memberEmails,
+                memberPasswords,
+                executionTimeMillis
+        );
     }
 }

--- a/src/main/java/com/loopone/loopinbe/global/webSocket/auth/JwtWsHandshakeInterceptor.java
+++ b/src/main/java/com/loopone/loopinbe/global/webSocket/auth/JwtWsHandshakeInterceptor.java
@@ -33,7 +33,7 @@ public class JwtWsHandshakeInterceptor implements HandshakeInterceptor {
         try {
             // 1) 토큰 추출 (Authorization: Bearer, or ?token=)
             String token = resolveToken(request);
-            if (token == null || !jwtTokenProvider.validateToken(token)) {
+            if (token == null || !jwtTokenProvider.validateAccessToken(token)) {
                 log.warn("[WS] invalid or missing token");
                 setUnauthorized(response);
                 return false;

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -52,7 +52,6 @@ frontend:
 
 fcm:
   service-account-file: classpath:fcm-service-account.json
-  project-id: 30409426097
 
 logging:
   level:

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -47,8 +47,7 @@ frontend:
   oauth-redirect: https://www.letzgo.site/login
 
 fcm:
-  service-account-file: file:/app/fcm-private-key.json
-  project-id: 30409426097
+  service-account-file: file:/home/ec2-user/deploy/fcm-service-account.json
 
 logging:
   level:


### PR DESCRIPTION
- NotProdMemberService 구현
- application-prod.yml에서 fcm-service-account.java 경로 수정
- SwaggerConfig 추가(BearerToken 기본설정 가능)
- accessToken 재발급 API 리팩토링 (@RequestHeader("Authorization-Refresh")로 헤더이름 변경)
- JwtAuthorizationFilter 리팩토링 (accessToken만 검증)
- Notification 도메인의 스웨거 태그 변경(FCM -> Notification)
- 회원 검색하기 API 수정(검색 결과에서 본인계정 제외)
- 회원 정보 수정 API 수정(@RequestPart MemberUpdateRequest memberUpdateRequest -> @ParameterObject @ModelAttribute MemberUpdateRequest memberUpdateRequest)
- 팔로우 요청하기 API 수정(자기 자신 팔로우 제한)
- MemberConverter, SimpleMemberMapper 수정
- NotificationServiceImpl 수정(checkPageSize에서 MemberPage -> NotificationPage 수정) -

## 🌟 기능 설명

<br>

## 🌟 swagger 테스트 성공 결과 스크린샷

<br>

## 🌟 연결된 issue
연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #57 
<br>
<br>

## 🌟 Approve 하기 전 확인해주세요!
- [ ] 리뷰어가 확인해줬으면 하는 사항 적어주세요.
<br>

## ✅ 체크리스트
- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 테스트 결과 사진을 넣었는가?
- [ ] 이슈넘버를 적었는가?
